### PR TITLE
docs: fix simple typo, wether -> whether

### DIFF
--- a/src/json/yajl/yajl_lex.c
+++ b/src/json/yajl/yajl_lex.c
@@ -330,7 +330,7 @@ yajl_lex_string(yajl_lexer lexer, const unsigned char * jsonText,
         /* accept it, and move on */ 
     }
   finish_string_lex:
-    /* tell our buddy, the parser, wether he needs to process this string
+    /* tell our buddy, the parser, whether he needs to process this string
      * again */
     if (hasEscapes && tok == yajl_tok_string) {
         tok = yajl_tok_string_with_escapes;


### PR DESCRIPTION
There is a small typo in src/json/yajl/yajl_lex.c.

Should read `whether` rather than `wether`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md